### PR TITLE
Fix TypeError on touch for mobile devices

### DIFF
--- a/components/action/InteractionHandler.tsx
+++ b/components/action/InteractionHandler.tsx
@@ -34,7 +34,7 @@ const InteractionHandler: FC<Props> = ({
 
   const touch = () => {
     setTouched(true)
-    setTouchedTime(new Date().getTime)
+    setTouchedTime(new Date().getTime())
 
     setTimeout(() => {
       if (new Date().getTime() - touchedTime > 150) {


### PR DESCRIPTION
On first screen touch on mobile devices I see in console:
```TypeError: this is not a Date object.```

